### PR TITLE
Variable err already defined

### DIFF
--- a/src/android/CordovaConekta.java
+++ b/src/android/CordovaConekta.java
@@ -70,11 +70,7 @@ public class CordovaConekta extends CordovaPlugin {
                 try {
                     callbackContext.success(data.getString("id"));
                 } catch (Exception err) {
-                    try {
-                        callbackContext.success(data.getString("id"));
-                    } catch (Exception err) {
-                        callbackContext.error(data);
-                    }
+                    callbackContext.error("Error: Token no pudo ser creado");
                 }
             }
         });


### PR DESCRIPTION
The try and catch section is duplicated and returns the following error:

... CordovaConekta.java:75: error: variable err is already defined in method onCreateTokenReady(JSONObject) ...