### PR TITLE
Switch UIWebView to WKWebView, Fixes Issue #2

### DIFF
--- a/src/ios/Conekta/Conekta.h
+++ b/src/ios/Conekta/Conekta.h
@@ -10,6 +10,7 @@
 #define Conekta_h
 
 #import <UIKit/UIKit.h>
+#import <WebKit/WebKit.h>
 #import <Foundation/Foundation.h>
 #import "Token.h"
 #import "Card.h"

--- a/src/ios/Conekta/Conekta.m
+++ b/src/ios/Conekta/Conekta.m
@@ -25,9 +25,8 @@
 
 - (void) collectDevice {
     NSString *html = [NSString stringWithFormat:@"<html style=\"background: blue;\"><head></head><body><script type=\"text/javascript\" src=\"https://conektaapi.s3.amazonaws.com/v0.5.0/js/conekta.js\" data-conekta-public-key=\"%@\" data-conekta-session-id=\"%@\"></script></body></html>", [self publicKey], [self deviceFingerprint]];
-    UIWebView *web = [[UIWebView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
+    WKWebView *web = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
     [web loadHTMLString:html baseURL:nil];
-    [web setScalesPageToFit:YES];
     [self.delegate.view addSubview:web];
 }
 
@@ -52,4 +51,3 @@
 }
 
 @end
-


### PR DESCRIPTION
https://github.com/nwrman/cordova-plugin-conekta/issues/2
According to Apple guidelines UIWebView is deprecated and shouldn't be used anymore, new apps and updates using it will be rejected. 

> Updating Apps that Use Web Views
> December 23, 2019
> 
> If your app still embeds web content using the deprecated UIWebView API, we strongly encourage you to update to WKWebView as soon as possible for improved security and reliability. WKWebView ensures that compromised web content doesn’t affect the rest of an app by limiting web processing to the app’s web view. And it’s supported in iOS and macOS, and by Mac Catalyst.
> 
> The App Store will no longer accept new apps using UIWebView as of April 2020 and app updates using UIWebView as of December 2020.

This switches UIWebView for WKWebView, unfortunately there is no equivalent for scalesPageToFit with WKWebView, but it didn't seem to be an issue when tested on our side.
Signed-off-by: marcorivm <marcorivm@gmail.com>